### PR TITLE
Remove deprecated jsonlib-python3 library

### DIFF
--- a/iotconnect-sdk-1.0/iotconnect/client/mqttclient.py
+++ b/iotconnect-sdk-1.0/iotconnect/client/mqttclient.py
@@ -3,8 +3,6 @@ import os
 import ssl as ssl
 import paho.mqtt.client as mqtt
 import json
-if ('linux' in sys.platform) and (sys.version_info >=(3,5)):
-    import jsonlib
 import time
 from iotconnect.IoTConnectSDKException import IoTConnectSDKException
 

--- a/iotconnect-sdk-1.0/setup.py
+++ b/iotconnect-sdk-1.0/setup.py
@@ -6,28 +6,26 @@ packages_requires=[]
 
 if 'win' in sys.platform:
     if sys.version_info >= (3, 5):
-        packages_requires=["paho-mqtt","ntplib","pypiwin32","jsonlib-python3"]
+        packages_requires=["paho-mqtt","ntplib","pypiwin32"]
     else:
         packages_requires=[]
         os.system('pip install paho-mqtt')
         os.system('pip install ntplib')
         os.system('pip install pypiwin32')
-        #os.system('pip install jsonlib')
 
 
 elif 'linux' in sys.platform :
     if sys.version_info >= (3, 5):
-        packages_requires=["paho-mqtt","ntplib","jsonlib-python3"]
+        packages_requires=["paho-mqtt","ntplib"]
     else:
         packages_requires=[]
         os.system('pip install paho-mqtt')
         os.system('pip install ntplib')
-        os.system('pip install jsonlib')
  
 setup(
     name="iotconnect-sdk",
     version="1.0",
-    python_requires=">=2.7,>=3.5,<3.9",
+    python_requires=">=2.7,>=3.5,<=3.10",
     description='SDK for D2C and C2D communication',
     license="MIT",
     author='SOFTWEB SOLUTIONS<admin@softwebsolutions.com> (https://www.softwebsolutions.com)',
@@ -41,6 +39,8 @@ setup(
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
         "License :: MIT License",
         "Operating System :: OS Independent"
     ],

--- a/iotconnect-sdk-1.0/setup.py
+++ b/iotconnect-sdk-1.0/setup.py
@@ -25,7 +25,7 @@ elif 'linux' in sys.platform :
 setup(
     name="iotconnect-sdk",
     version="1.0",
-    python_requires=">=2.7,>=3.5,<=3.10",
+    python_requires=">=2.7,>=3.5,<3.11",
     description='SDK for D2C and C2D communication',
     license="MIT",
     author='SOFTWEB SOLUTIONS<admin@softwebsolutions.com> (https://www.softwebsolutions.com)',


### PR DESCRIPTION
The jsonlib library is deprecated and incompatible with python versions greater than 3.7, resulting in an error when attempting to install the sdk on newer versions of python.

I removed jsonlib from the installation requirements and the mqtt_client.py file. The standard python json library has the same functionality.

I also updated the maximum python version to the latest stable version of python (3.10).


